### PR TITLE
More logging 🔥

### DIFF
--- a/entity.go
+++ b/entity.go
@@ -87,14 +87,14 @@ func (m *migrator) MigrateDatabase(migrations []Migration) error {
 			migrations[i].order = i + 1
 			err = m.driver.writeMigration(migrations[i])
 			if err != nil {
-				log.Fatalf("Unable to write migration: %v", err)
+				log.Fatalf("Unable to write migration to migration table for number %v with name: %v due to error: %v", i+1, migrations[i].Name, err)
 			}
 
 			_, err := m.db.Exec(migrations[i].Script)
 
 			if err != nil {
 				m.driver.updateStatus(FAILED, i+1)
-				log.Fatalf("Unable to write migration: %v", err)
+				log.Fatalf("Unable to apply migration script for migration number %v, with name: %v due to error %v", i+1, migrations[i].Name, err)
 			}
 
 			err = m.driver.updateStatus(COMPLETE, i+1)


### PR DESCRIPTION
Weak logging made it hard to see what script is failing Added more logging to migration step. Users of the package should now see which script is failing and if it is due to writing to the migration table or the migration script itself.